### PR TITLE
Add cest-codeowners team to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,6 @@
-* @oNaiPs
+# CODEOWNERS file
+# This file defines the default code owners for this repository.
+# Code owners are automatically requested for review when someone opens a pull request.
+
+# Default owner for everything in the repo
+* @porterin/cest-codeowners

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # Code owners are automatically requested for review when someone opens a pull request.
 
 # Default owner for everything in the repo
-* @porterin/cest-codeowners
+* @porterin/cest-codeowners @porterin/cest-core-engineering-codeowners


### PR DESCRIPTION
## Summary
This PR adds the `@porterin/cest-codeowners` team to the CODEOWNERS file.

## Changes
- Updated CODEOWNERS file
- Added `@porterin/cest-codeowners` as code owner

## Notes
- This ensures the cest codeowners team is automatically requested for review on all PRs
- Generated automatically by GitHub automation

🤖 Generated with automation